### PR TITLE
wpasupplicant: Add wpa_supplicant configuration restore if it's corrupts

### DIFF
--- a/wificontrol/utils/fileupdater.py
+++ b/wificontrol/utils/fileupdater.py
@@ -124,8 +124,12 @@ class ConfigurationFileUpdater(object):
             return [self.__parse_network(network) for network in raw_networks.strip().split('\n\n')]
 
     def __parse_network(self, raw_network):
-        param_pair_list = raw_network[raw_network.find('\t'):raw_network.find('}')].strip().split('\n')
-        return {key.strip(): parameter.strip("\"") for key, parameter in (param_pair.split('=', 1) for param_pair in param_pair_list)}
+        try:
+            param_pair_list = raw_network[raw_network.find('\t'):raw_network.find('}')].strip().split('\n')
+        except ValueError:
+            return None
+        else:
+            return {key.strip(): parameter.strip("\"") for key, parameter in (param_pair.split('=', 1) for param_pair in param_pair_list)}
 
     def __create_config_file(self):
         return self.head + '\n' + '\n'.join([str(NetworkTemplate(network)) for network in self.networks])

--- a/wificontrol/wifireconnect.py
+++ b/wificontrol/wifireconnect.py
@@ -24,10 +24,12 @@
 
 import dbus
 import signal
-import threading
 import logging
+import threading
+
 from daemon_tree import DaemonTreeSvr
 from wificontrol import WiFiControl
+
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### It's important!
This pull request goes in pairs with pull request in systemd-manager https://github.com/emlid/systemd-manager/pull/2
#### Changes
* Add check for errors in wpasupplicant.py and restore configuration to default if wpa_supplicant.service raise error related to parsing configuration file
* Change the addition and removal of networks
* Known networks are located in separate files in the path `/etc/wpa_supplicant/networks`
### Requirements:
Need to create default configurations of wpa_supplicant in the file at path: `/etc/wpa_supplicant/wpa_supplicant.conf.default`
Need to append to the wpa_supplicant.service file at path `/lib/systemd/system/wpa_supplicant.service` option `ExecStartPre` with value: 
```
ExecStartPre=/bin/bash -c '[ -d "/etc/wpa_supplicant/networks" ] && cat /etc/wpa_supplicant/wpa_supplicant.conf.default /etc/wpa_supplicant/networks/*.netconf > /etc/wpa_supplicant/wpa_supplicant.conf || cp /etc/wpa_supplicant/wpa_supplicant.conf.default /etc/wpa_supplicant/wpa_supplicant.conf'
```