### PR TITLE
Update pywificontrol naming 

### DIFF
--- a/tools/init_wifi.py
+++ b/tools/init_wifi.py
@@ -37,7 +37,7 @@
 
 import sys
 
-from wificontrol import WiFiControl
+from wificontrol import WiFiControl, WiFiControlError
 
 
 def _show_result(result, wifi_controller):
@@ -53,7 +53,7 @@ def _show_result(result, wifi_controller):
 def initialize():
     try:
         wifi_controller = WiFiControl()
-    except OSError:
+    except WiFiControlError:
         sys.stdout.write("Network mode: unknown")
     else:
         wifi_controller.turn_on_wifi()

--- a/wificontrol/hostapd.py
+++ b/wificontrol/hostapd.py
@@ -34,7 +34,7 @@
 
 
 import os
-from wificommon import WiFi
+from wificommon import WiFi, WiFiControlError
 
 
 class HostAP(WiFi):
@@ -49,7 +49,7 @@ class HostAP(WiFi):
         self.hostname_path = hostname_config
 
         if (b'bin/hostapd' not in self.execute_command("whereis hostapd")):
-            raise OSError('No HOSTAPD servise')
+            raise WiFiControlError('No HOSTAPD servise')
 
         self.started = lambda: self.sysdmanager.is_active("hostapd.service")
 

--- a/wificontrol/hostapd.py
+++ b/wificontrol/hostapd.py
@@ -72,7 +72,10 @@ class HostAP(WiFi):
         return self.verify_hostap_password(password)
 
     def verify_hostap_password(self, value):
-        return self.re_search("(?<=^wpa_passphrase=).*", self.hostapd_path) == value
+        return self.get_hostap_password() == value
+
+    def get_hostap_password(self):
+        return self.re_search("(?<=^wpa_passphrase=).*", self.hostapd_path)
 
     def set_host_name(self, name='reach'):
         try:

--- a/wificontrol/utils/networkstranslate.py
+++ b/wificontrol/utils/networkstranslate.py
@@ -33,24 +33,31 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+OPEN_SEC = "open"
+WEP_SEC = "wep"
+WPA_SEC = "wpa"
+WPAPSK_SEC = "wpa-psk"
+WPAEAP_SEC = "wpa-eap"
+
+
 def create_security(proto, key_mgmt, group):
     if not proto:
-        return 'open'
+        return OPEN_SEC
     if not key_mgmt:
         if "wep" in group:
-            return 'wep'
+            return WEP_SEC
         else:
             return None
     else:
         if "wpa-psk" in key_mgmt:
             if proto == "WPA":
-                return "wpapsk"
+                return WPA_SEC
             elif proto == "RSN":
-                return "wpa2psk"
+                return WPAPSK_SEC
             else:
                 return None
         elif "wpa-eap" in key_mgmt:
-            return 'wpaeap'
+            return WPAEAP_SEC
         else:
             return None
 
@@ -80,22 +87,22 @@ class WpasNetworkConverter(object):
         self.identity = network_dict.get('identity', '').encode('utf-8')
 
     def __iter__(self):
-        if (self.security == 'open'):
+        if (self.security == OPEN_SEC):
             yield "ssid", "{}".format(self.name)
             yield "key_mgmt", "NONE"
-        elif (self.security == 'wep'):
+        elif (self.security == WEP_SEC):
             yield "ssid", "{}".format(self.name)
             yield "key_mgmt", "NONE"
             yield "group", "WEP104 WEP40"
             yield "wep_key0", "{}".format(self.password)
-        elif (self.security == 'wpapsk'):
+        elif (self.security == WPA_SEC):
             yield "ssid", "{}".format(self.name)
             yield "key_mgmt", "WPA-PSK"
             yield "pairwise", "CCMP TKIP"
             yield "group", "CCMP TKIP"
             yield "eap", "TTLS PEAP TLS"
             yield "psk", "{}".format(self.password)
-        elif (self.security == 'wpa2psk'):
+        elif (self.security == WPAPSK_SEC):
             yield "ssid", "{}".format(self.name)
             yield "proto", "RSN"
             yield "key_mgmt", "WPA-PSK"
@@ -103,7 +110,7 @@ class WpasNetworkConverter(object):
             yield "group", "CCMP TKIP"
             yield "eap", "TTLS PEAP TLS"
             yield "psk", "{}".format(self.password)
-        elif (self.security == 'wpaeap'):
+        elif (self.security == WPAEAP_SEC):
             yield "ssid", "{}".format(self.name)
             yield "key_mgmt", "WPA-EAP"
             yield "pairwise", "CCMP TKIP"
@@ -129,26 +136,26 @@ class WifiControlNetworkConverter(object):
         if (self.key_mgmt == 'NONE'):
             if not self.group:
                 yield "ssid", self.name
-                yield "security", "Open"
+                yield "security", OPEN_SEC
             else:
                 yield "ssid", self.name
-                yield "security", "WEP"
+                yield "security", WEP_SEC
 
         elif (self.key_mgmt == 'WPA-PSK'):
             if not self.proto:
                 yield "ssid", self.name
-                yield "security", "WPA-PSK"
+                yield "security", WPA_SEC
             else:
                 yield "ssid", self.name
-                yield "security", "WPA2-PSK"
+                yield "security", WPAPSK_SEC
 
         elif (self.key_mgmt == 'WPA-EAP'):
             yield "ssid", self.name
-            yield "security", "WPA-EAP"
+            yield "security", WPAEAP_SEC
 
         else:
             yield "ssid", self.name
-            yield "security", "NONE"
+            yield "security", OPEN_SEC
         yield "connected", False
 
 

--- a/wificontrol/wifimonitor.py
+++ b/wificontrol/wifimonitor.py
@@ -200,8 +200,6 @@ class WiFiMonitor(object):
                     callback(*args)
                 except Exception as error:
                     logger.error('Callback {} execution error. {}'.format(callback.__name__, error))
-                except WiFiMonitorError as error:
-                    logger.error(error)
 
     def run(self):
         try:

--- a/wificontrol/wpasupplicant.py
+++ b/wificontrol/wpasupplicant.py
@@ -33,7 +33,7 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from wificommon import WiFi
+from wificommon import WiFi, WiFiControlError
 from utils import CfgFileUpdater
 from utils import WpaSupplicantInterface, WpaSupplicantNetwork, WpaSupplicantBSS
 from utils import convert_to_wpas_network, convert_to_wificontrol_network, \
@@ -59,7 +59,7 @@ class WpaSupplicant(WiFi):
 
         if (b'bin/wpa_supplicant' not in self.execute_command(
                 "whereis wpa_supplicant")):
-            raise OSError('No WPA_SUPPLICANT service')
+            raise WiFiControlError('No WPA_SUPPLICANT service')
 
         self.wpa_supplicant_interface = WpaSupplicantInterface(self.interface)
         self.wpa_bss_manager = WpaSupplicantBSS()

--- a/wificontrol/wpasupplicant.py
+++ b/wificontrol/wpasupplicant.py
@@ -93,8 +93,8 @@ class WpaSupplicant(WiFi):
         if self.started():
             network_params = dict()
             network_params['ssid'] = self.get_current_network_ssid()
-            network_params['mac address'] = self.get_device_mac()
-            network_params['IP address'] = self.get_device_ip()
+            network_params['mac_address'] = self.get_device_mac()
+            network_params['ip'] = self.get_device_ip()
         return network_params
 
     def scan(self):


### PR DESCRIPTION
* Use `WiFiControlError` if something went wrong instead of `OSError`
* Make wifi-security constants consistent with NetworkManager constants
* Minor naming fixes